### PR TITLE
Template baseDN and userDN in serverAppContext.xml

### DIFF
--- a/src/main/resources/serverAppContext.xml
+++ b/src/main/resources/serverAppContext.xml
@@ -45,8 +45,8 @@
     <!-- LDAP helpers -->
     <bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
         <property name="url" value="${url}" /><!-- something like ldap://localhost:9389 -->
-        <property name="base" value="ou=people,dc=jenkins-ci,dc=org" />
-        <property name="userDn" value="cn=admin,dc=jenkins-ci,dc=org" />
+        <property name="base" value="${baseDN}" />
+        <property name="userDn" value="${username}" />
         <property name="password" value="${password}" />
     </bean>
     <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">


### PR DESCRIPTION
We allow the configuration of the password but not the username and now that account app use a different dn than `cn=admin,dc=jenkins-ci,dc=org`, we also need a new way to configure this dn 